### PR TITLE
Add more seat statistics in Admin Page

### DIFF
--- a/components/admin/stats.tsx
+++ b/components/admin/stats.tsx
@@ -30,7 +30,24 @@ export const Stats: React.FC<StatsProps> = ({ customers, tickets, seats }) => {
     const checkedInTickets = Object.values(tickets).filter(t => t.checkedIn).length;
 
     const totalSeats = Object.keys(seats).length;
+    const notSelectableSeats = Object.values(seats).filter(s => s.notSelectable === true).length;
     const reservedSeats = Object.values(seats).filter(s => !s.isAvailable).length;
+
+    const catASeats = Object.values(seats).filter(s => s.category === 'catA').length;
+    const catBSeats = Object.values(seats).filter(s => s.category === 'catB').length;
+    const catCSeats = Object.values(seats).filter(s => s.category === 'catC').length;
+
+    const catANotSelectableSeats = Object.values(seats).filter(s => s.category === 'catA' && s.notSelectable === true).length;
+    const catAReservedSeats = Object.values(seats).filter(s => s.category === 'catA' && !s.isAvailable).length;
+    const catAAvailableSeats = Object.values(seats).filter(s => s.category === 'catA' && s.isAvailable).length;
+
+    const catBNotSelectableSeats = Object.values(seats).filter(s => s.category === 'catB' && s.notSelectable === true).length;
+    const catBReservedSeats = Object.values(seats).filter(s => s.category === 'catB' && !s.isAvailable).length;
+    const catBAvailableSeats = Object.values(seats).filter(s => s.category === 'catB' && s.isAvailable).length;
+
+    const catCNotSelectableSeats = Object.values(seats).filter(s => s.category === 'catC' && s.notSelectable === true).length;
+    const catCReservedSeats = Object.values(seats).filter(s => s.category === 'catC' && !s.isAvailable).length;
+    const catCAvailableSeats = Object.values(seats).filter(s => s.category === 'catC' && s.isAvailable).length;
 
     const makeData = (data: number[], titles: string[], colors: string[]) => data.map((value, index) => ({
         name: titles[index],
@@ -97,8 +114,28 @@ export const Stats: React.FC<StatsProps> = ({ customers, tickets, seats }) => {
             {
                 key: 'seats',
                 label: 'Seats Status',
-                data: makeData([totalSeats - reservedSeats, reservedSeats], ['Available', 'Reserved'], COLORS),
+                data: makeData([totalSeats - reservedSeats - notSelectableSeats, reservedSeats, notSelectableSeats], ['Available', 'Reserved', 'Not Selectable'], COLORS),
             },
+            {
+                key: 'seatsCategories',
+                label: 'Seats Categories',
+                data: makeData([catASeats, catBSeats, catCSeats], ['Category A', 'Category B', 'Category C'], COLORS),
+            },
+            {
+                key: 'seatsCategoryA',
+                label: 'Category A Seats Status',
+                data: makeData([catAAvailableSeats, catAReservedSeats, catANotSelectableSeats], ['Available', 'Reserved', 'Not Selectable'], COLORS),
+            },
+            {
+                key: 'seatsCategoryB',
+                label: 'Category B Seats Status',
+                data: makeData([catBAvailableSeats, catBReservedSeats, catBNotSelectableSeats], ['Available', 'Reserved', 'Not Selectable'], COLORS),
+            },
+            {
+                key: 'seatsCategoryC',
+                label: 'Category C Seats Status',
+                data: makeData([catCAvailableSeats, catCReservedSeats, catCNotSelectableSeats], ['Available', 'Reserved', 'Not Selectable'], COLORS),
+            }
             ].map(({ key, label, data }) => {
                 const totalValue = data.reduce((sum, d) => sum + d.value, 0);
                 const percent = data[0].value && totalValue


### PR DESCRIPTION
This pull request enhances the `Stats` component in `components/admin/stats.tsx` to provide more detailed statistics on seat statuses and categories. The changes introduce new calculations and visualizations for seat availability, reservation, and non-selectability, segmented by categories.

### Seat Status Enhancements:
* Added calculation for `notSelectableSeats` to track seats that are not selectable. Updated the visualization to include this status alongside available and reserved seats. [[1]](diffhunk://#diff-a446b356190fa100b4a41ffdb6e4795fd8f4ee0b183b6569ba1fc71b2bbb56bbR33-R51) [[2]](diffhunk://#diff-a446b356190fa100b4a41ffdb6e4795fd8f4ee0b183b6569ba1fc71b2bbb56bbL100-R138)

### Seat Category Segmentation:
* Introduced calculations for seats categorized as `catA`, `catB`, and `catC`, including their availability, reservation, and non-selectability statuses.
* Added new visualizations for overall seat distribution across categories (`catASeats`, `catBSeats`, `catCSeats`) and detailed status breakdowns within each category (available, reserved, not selectable).

### Related Issues:
* Resolve #60 