### PR TITLE
Add feature to copy entries in the admin table

### DIFF
--- a/components/admin/customer-table.tsx
+++ b/components/admin/customer-table.tsx
@@ -10,6 +10,7 @@ import {
 } from 'ag-grid-community';
 import { darkGreenTheme } from '@/app/ag-grid-theme';
 import { Customer } from '@/lib/db';
+import { useGridCopy } from '@/components/admin/use-grid-copy';
 
 ModuleRegistry.registerModules([AllCommunityModule]);
 
@@ -19,6 +20,7 @@ export const CustomerTable: React.FC<{ customers: Record<string, Customer> }> = 
     gridApi.current = e.api;
     e.api.sizeColumnsToFit();
   }
+  const handleKeyDown = useGridCopy(gridApi);
 
   const defaultColDef: GridOptions['defaultColDef'] = {
     flex: 1,
@@ -47,7 +49,7 @@ export const CustomerTable: React.FC<{ customers: Record<string, Customer> }> = 
   }
 
   return (
-    <div style={{ width: '100%' }}>
+    <div className="w-full select-text" tabIndex={0} onKeyDown={handleKeyDown}>
       <AgGridReact
         theme={darkGreenTheme}
         domLayout="autoHeight"
@@ -57,6 +59,7 @@ export const CustomerTable: React.FC<{ customers: Record<string, Customer> }> = 
         onGridReady={gridOnReady}
         pagination={true}
         animateRows={true}
+        enableCellTextSelection
       />
       <button
         onClick={exportCsv}

--- a/components/admin/joined-seat-table.tsx
+++ b/components/admin/joined-seat-table.tsx
@@ -9,6 +9,7 @@ import {
 } from 'ag-grid-community';
 import { darkGreenTheme } from '@/app/ag-grid-theme';
 import { Customer, Seat, Ticket } from '@/lib/db';
+import { useGridCopy } from '@/components/admin/use-grid-copy';
 
 ModuleRegistry.registerModules([AllCommunityModule]);
 
@@ -22,6 +23,7 @@ export const JoinedSeatTable: React.FC<{
       gridApi.current = e.api;
       e.api.sizeColumnsToFit();
     }
+    const handleKeyDown = useGridCopy(gridApi);
 
     const rowData = useMemo(() =>
         Object.values(seats).map(s => {
@@ -72,7 +74,7 @@ export const JoinedSeatTable: React.FC<{
   }
 
   return (
-    <div style={{ width: '100%' }}>
+    <div className="w-full select-text" tabIndex={0} onKeyDown={handleKeyDown}>
       <AgGridReact
         theme={darkGreenTheme}
         domLayout="autoHeight"
@@ -82,6 +84,7 @@ export const JoinedSeatTable: React.FC<{
         pagination={true}
         animateRows={true}
         onGridReady={gridOnReady}
+        enableCellTextSelection
       />
       <button
         onClick={exportCsv}

--- a/components/admin/joined-ticket-table.tsx
+++ b/components/admin/joined-ticket-table.tsx
@@ -9,6 +9,7 @@ import {
 } from 'ag-grid-community';
 import { darkGreenTheme } from '@/app/ag-grid-theme';
 import { Customer, Ticket } from '@/lib/db';
+import { useGridCopy } from '@/components/admin/use-grid-copy';
 
 ModuleRegistry.registerModules([ AllCommunityModule ]);
 
@@ -21,6 +22,7 @@ export const JoinedTicketTable: React.FC<{
         gridApi.current = e.api;
         e.api.sizeColumnsToFit();
     }
+    const handleKeyDown = useGridCopy(gridApi);
     // Join tickets, customer, seat
     const rowData = useMemo(() => Object.values(tickets).map(t => {
         const owner = Object.entries(customers).find(([_, c]) => c.ticketIds.includes(t.id))?.[1];
@@ -69,7 +71,7 @@ export const JoinedTicketTable: React.FC<{
     }
 
     return (
-        <div style={{ width: '100%' }}>
+        <div className="w-full select-text" tabIndex={0} onKeyDown={handleKeyDown}>
         <AgGridReact
             theme={darkGreenTheme}
             domLayout="autoHeight"
@@ -79,6 +81,7 @@ export const JoinedTicketTable: React.FC<{
             onGridReady={gridOnReady}
             pagination={true}
             animateRows={true}
+            enableCellTextSelection
         />
         <button
             onClick={exportCsv}

--- a/components/admin/seat-table.tsx
+++ b/components/admin/seat-table.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { AgGridReact } from 'ag-grid-react';
 import {
   ModuleRegistry,
@@ -6,14 +6,21 @@ import {
   GridOptions,
   ColDef,
   GridReadyEvent,
+  GridApi,
 } from 'ag-grid-community';
 import { darkGreenTheme } from '@/app/ag-grid-theme';
 import { Seat } from '@/lib/db';
+import { useGridCopy } from '@/components/admin/use-grid-copy';
 
 ModuleRegistry.registerModules([AllCommunityModule]);
 
 export const SeatTable: React.FC<{ seats: Record<string, Seat> }> = ({ seats }) => {
-  const gridOnReady = (e: GridReadyEvent) => e.api.sizeColumnsToFit();
+  const gridApi = useRef<GridApi | null>(null);
+  const gridOnReady = (e: GridReadyEvent) => {
+    gridApi.current = e.api;
+    e.api.sizeColumnsToFit();
+  };
+  const handleKeyDown = useGridCopy(gridApi);
 
   const defaultColDef: GridOptions['defaultColDef'] = {
     flex: 1,
@@ -34,7 +41,7 @@ export const SeatTable: React.FC<{ seats: Record<string, Seat> }> = ({ seats }) 
   ];
 
   return (
-    <div style={{ width: '100%' }}>
+    <div className="w-full select-text" tabIndex={0} onKeyDown={handleKeyDown}>
       <AgGridReact
         theme={darkGreenTheme}
         domLayout="autoHeight"

--- a/components/admin/ticket-table.tsx
+++ b/components/admin/ticket-table.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { AgGridReact } from 'ag-grid-react';
 import {
   ModuleRegistry,
@@ -6,14 +6,21 @@ import {
   GridOptions,
   ColDef,
   GridReadyEvent,
+  GridApi,
 } from 'ag-grid-community';
 import { darkGreenTheme } from '@/app/ag-grid-theme';
 import { Ticket } from '@/lib/db';
+import { useGridCopy } from '@/components/admin/use-grid-copy';
 
 ModuleRegistry.registerModules([AllCommunityModule]);
 
 export const TicketTable: React.FC<{ tickets: Record<string, Ticket> }> = ({ tickets }) => {
-  const gridOnReady = (e: GridReadyEvent) => e.api.sizeColumnsToFit();
+  const gridApi = useRef<GridApi | null>(null);
+  const gridOnReady = (e: GridReadyEvent) => {
+    gridApi.current = e.api;
+    e.api.sizeColumnsToFit();
+  };
+  const handleKeyDown = useGridCopy(gridApi);
 
   const defaultColDef: GridOptions['defaultColDef'] = {
     flex: 1,
@@ -35,7 +42,7 @@ export const TicketTable: React.FC<{ tickets: Record<string, Ticket> }> = ({ tic
   ];
 
   return (
-    <div style={{ width: '100%' }}>
+    <div className="w-full select-text" tabIndex={0} onKeyDown={handleKeyDown}>
       <AgGridReact
         theme={darkGreenTheme}
         domLayout="autoHeight"
@@ -45,6 +52,7 @@ export const TicketTable: React.FC<{ tickets: Record<string, Ticket> }> = ({ tic
         onGridReady={gridOnReady}
         pagination={true}
         animateRows={true}
+        enableCellTextSelection
       />
     </div>
   );

--- a/components/admin/use-grid-copy.tsx
+++ b/components/admin/use-grid-copy.tsx
@@ -1,0 +1,31 @@
+import { useCallback, RefObject } from 'react';
+import type { GridApi } from 'ag-grid-community';
+
+export function useGridCopy(gridApi: RefObject<GridApi | null>) {
+  return useCallback((e: React.KeyboardEvent) => {
+    if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'c') {
+      const selection = window.getSelection();
+      if (selection && !selection.isCollapsed) return;
+
+      const api = gridApi.current;
+      if (!api) return;
+      const focused = api.getFocusedCell();
+      if (!focused) return;
+      const rowNode = api.getDisplayedRowAtIndex(focused.rowIndex);
+      const value = rowNode?.data?.[focused.column.getColId()];
+      if (value == null) return;
+      const text = String(value);
+      navigator.clipboard?.writeText(text).catch(() => {
+        const textarea = document.createElement('textarea');
+        textarea.value = text;
+        textarea.style.position = 'fixed';
+        textarea.style.opacity = '0';
+        document.body.appendChild(textarea);
+        textarea.focus();
+        textarea.select();
+        try { document.execCommand('copy'); } catch { /* noop */ }
+        document.body.removeChild(textarea);
+      });
+    }
+  }, [gridApi]);
+}


### PR DESCRIPTION
This pull request enhances the admin data tables by adding keyboard copy-to-clipboard support for individual cell values. Now, pressing Ctrl+C or Cmd+C when a cell is focused copies its value, even if no text is selected. This is achieved by introducing a reusable `useGridCopy` hook and updating all relevant table components to use it. Additionally, some UI improvements were made for better accessibility and text selection.

**Keyboard copy-to-clipboard functionality:**

* Added a new `useGridCopy` React hook in `use-grid-copy.tsx` to handle keyboard events and copy the focused cell's value to the clipboard, with a fallback for unsupported browsers.
* Integrated `useGridCopy` into all admin table components (`customer-table.tsx`, `joined-seat-table.tsx`, `joined-ticket-table.tsx`, `seat-table.tsx`, `ticket-table.tsx`), wiring up the `onKeyDown` event and passing the grid API reference. [[1]](diffhunk://#diff-358b4858369e4608485a12f81ab96a1b66f1aa7d4595f8f37d946f307f5b559dR13) [[2]](diffhunk://#diff-358b4858369e4608485a12f81ab96a1b66f1aa7d4595f8f37d946f307f5b559dR23) [[3]](diffhunk://#diff-efd3716cce223caaa2f48a47b4d596b80afa863e2fb70a89446ce6916daf65f0R12) [[4]](diffhunk://#diff-efd3716cce223caaa2f48a47b4d596b80afa863e2fb70a89446ce6916daf65f0R26) [[5]](diffhunk://#diff-981f48b32bad03021f6476c17165a11132fbb86d0f20669d1dcb5bd9e70ffccaR12) [[6]](diffhunk://#diff-981f48b32bad03021f6476c17165a11132fbb86d0f20669d1dcb5bd9e70ffccaR25) [[7]](diffhunk://#diff-d0de8fef0e308bd0bc6881373340f96146bf310b77000a0251f48312a56be671L1-R23) [[8]](diffhunk://#diff-0c9b8799d9df22b4b26f88ca031468554c2d6787d813b4e04273c4b36fadba3aL1-R23)

**UI and accessibility improvements:**

* Updated the table container `<div>` for all admin tables to use utility classes for full width and text selection, added `tabIndex={0}` for keyboard focus, and attached the new `onKeyDown` handler. [[1]](diffhunk://#diff-358b4858369e4608485a12f81ab96a1b66f1aa7d4595f8f37d946f307f5b559dL50-R52) [[2]](diffhunk://#diff-efd3716cce223caaa2f48a47b4d596b80afa863e2fb70a89446ce6916daf65f0L75-R77) [[3]](diffhunk://#diff-981f48b32bad03021f6476c17165a11132fbb86d0f20669d1dcb5bd9e70ffccaL72-R74) [[4]](diffhunk://#diff-d0de8fef0e308bd0bc6881373340f96146bf310b77000a0251f48312a56be671L37-R44) [[5]](diffhunk://#diff-0c9b8799d9df22b4b26f88ca031468554c2d6787d813b4e04273c4b36fadba3aL38-R45)
* Enabled cell text selection in all `AgGridReact` components by passing the `enableCellTextSelection` prop. [[1]](diffhunk://#diff-358b4858369e4608485a12f81ab96a1b66f1aa7d4595f8f37d946f307f5b559dR62) [[2]](diffhunk://#diff-efd3716cce223caaa2f48a47b4d596b80afa863e2fb70a89446ce6916daf65f0R87) [[3]](diffhunk://#diff-981f48b32bad03021f6476c17165a11132fbb86d0f20669d1dcb5bd9e70ffccaR84) [[4]](diffhunk://#diff-0c9b8799d9df22b4b26f88ca031468554c2d6787d813b4e04273c4b36fadba3aR55)