### PR TITLE
Add customer creation tab for admin dashboard

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -15,6 +15,7 @@ import { CustomerTable } from '@/components/admin/customer-table';
 import { JoinedTicketTable } from '@/components/admin/joined-ticket-table';
 import { JoinedSeatTable } from '@/components/admin/joined-seat-table';
 import { TicketCheckIn } from '@/components/admin/ticket-checkin';
+import { CustomerCreate } from '@/components/admin/customer-create';
 import { Customer, Seat, Ticket } from '@/lib/db';
 import { clearLocalStorage, updateData, useLocalStorage } from '@/app/local-storage';
 
@@ -23,8 +24,8 @@ ModuleRegistry.registerModules([AllCommunityModule]);
 
 ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend);
 
-type Tab = 'CheckIn' | 'Customers' | 'Tickets' | 'Seats' | 'Statistics';
-const tabs: Tab[] = ['CheckIn', 'Customers', 'Tickets', 'Seats', 'Statistics'];
+type Tab = 'CheckIn' | 'Customers' | 'Tickets' | 'Seats' | 'Statistics' | 'CreateCustomer';
+const tabs: Tab[] = ['CheckIn', 'Customers', 'Tickets', 'Seats', 'Statistics', 'CreateCustomer'];
 
 export default function AdminPage() {
   // Authentication state
@@ -202,7 +203,7 @@ export default function AdminPage() {
               cursor: 'pointer',
             }}
           >
-            {tab === 'CheckIn' ? 'Ticket Check-In' : tab}
+            {tab === 'CheckIn' ? 'Ticket Check-In' : tab === 'CreateCustomer' ? 'Create Customer' : tab}
           </button>
         ))}
       </nav>
@@ -212,6 +213,7 @@ export default function AdminPage() {
         {activeTab === 'Tickets' && <JoinedTicketTable tickets={tickets} customers={customers} />}
         {activeTab === 'Seats' && <JoinedSeatTable tickets={tickets} customers={customers} seats={seats} />}
         {activeTab === 'Statistics' && <Stats customers={customers} tickets={tickets} seats={seats} />}
+        {activeTab === 'CreateCustomer' && <CustomerCreate />}
       </main>
 
       <button

--- a/app/api/createCustomer/route.tsx
+++ b/app/api/createCustomer/route.tsx
@@ -5,7 +5,7 @@ import { ApiError, UnauthorizedError } from '@/lib/error';
 import { db } from '@/db/source';
 import { collection, addDoc, Timestamp, query, where, getDocs } from 'firebase/firestore';
 
-async function generateUniqueCode(prefix = 'D_DAY', length = 8) {
+async function generateUniqueCode(prefix, length = 8) {
   const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
   for (let attempt = 0; attempt < 5; attempt++) {
     let random = '';
@@ -31,13 +31,16 @@ export async function POST(request: NextRequest) {
     }
     await verifyAdmin(token);
 
-    const { email, catA = 0, catB = 0, catC = 0 } = await request.json();
+    const { email, prefix, catA = 0, catB = 0, catC = 0 } = await request.json();
     if (!email) {
       return NextResponse.json({ error: 'Field `email` required' }, { status: 400 });
     }
+    if (!prefix) {
+      return NextResponse.json({ error: 'Field `prefix` required' }, { status: 400 });
+    }
 
     const now = Timestamp.now();
-    const code = await generateUniqueCode();
+    const code = await generateUniqueCode(prefix);
     const ticketRef = await addDoc(collection(db, 'tickets'), {
       code,
       catA: Number(catA) || 0,

--- a/app/api/createCustomer/route.tsx
+++ b/app/api/createCustomer/route.tsx
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { verifyAdmin } from '@/lib/auth';
+import { ApiError, UnauthorizedError } from '@/lib/error';
+import { db } from '@/db/source';
+import { collection, doc, setDoc, Timestamp } from 'firebase/firestore';
+
+function generateCode(length = 8) {
+  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+  let result = '';
+  for (let i = 0; i < length; i++) {
+    result += chars.charAt(Math.floor(Math.random() * chars.length));
+  }
+  return result;
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const token = (await cookies()).get('token')?.value;
+    if (!token) {
+      throw new UnauthorizedError();
+    }
+    await verifyAdmin(token);
+
+    const { email, catA = 0, catB = 0, catC = 0 } = await request.json();
+    if (!email) {
+      return NextResponse.json({ error: 'Field `email` required' }, { status: 400 });
+    }
+
+    const now = Timestamp.now();
+    const ticketRef = doc(collection(db, 'tickets'));
+    const ticketId = ticketRef.id;
+    const code = generateCode();
+    await setDoc(ticketRef, {
+      code,
+      catA: Number(catA) || 0,
+      catB: Number(catB) || 0,
+      catC: Number(catC) || 0,
+      seatConfirmed: false,
+      checkedIn: false,
+      lastUpdated: now,
+    });
+
+    const customerRef = doc(collection(db, 'customers'));
+    await setDoc(customerRef, {
+      email,
+      ticketIds: [ticketId],
+      lastUpdated: now,
+    });
+
+    return NextResponse.json({ success: true, ticket: { id: ticketId, code } }, { status: 200 });
+  } catch (error: any) {
+    if (error instanceof ApiError) {
+      return NextResponse.json({ error: error.message }, { status: error.status });
+    }
+    console.error(error);
+    return NextResponse.json({ error: 'Failed to create customer' }, { status: 500 });
+  }
+}

--- a/app/api/createCustomer/route.tsx
+++ b/app/api/createCustomer/route.tsx
@@ -5,7 +5,7 @@ import { ApiError, UnauthorizedError } from '@/lib/error';
 import { db } from '@/db/source';
 import { collection, addDoc, Timestamp, query, where, getDocs } from 'firebase/firestore';
 
-async function generateUniqueCode(prefix, length = 8) {
+async function generateUniqueCode(prefix: string, length: number = 8) {
   const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
   for (let attempt = 0; attempt < 5; attempt++) {
     let random = '';

--- a/app/api/createCustomer/route.tsx
+++ b/app/api/createCustomer/route.tsx
@@ -43,8 +43,11 @@ export async function POST(request: NextRequest) {
       catA: Number(catA) || 0,
       catB: Number(catB) || 0,
       catC: Number(catC) || 0,
+      customerEmail: email,
       seatConfirmed: false,
       checkedIn: false,
+      createdAt: now,
+      purchaseConfirmationSent: false,
       lastUpdated: now,
     });
     const ticketId = ticketRef.id;

--- a/app/api/createCustomer/route.tsx
+++ b/app/api/createCustomer/route.tsx
@@ -5,14 +5,47 @@ import { ApiError, UnauthorizedError } from '@/lib/error';
 import { db } from '@/db/source';
 import { collection, addDoc, Timestamp } from 'firebase/firestore';
 
-function generateCode(length = 8) {
-  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
-  let result = '';
-  for (let i = 0; i < length; i++) {
-    result += chars.charAt(Math.floor(Math.random() * chars.length));
+const BASE62 = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+
+function toBase62(num: number, length: number = 4): string {
+  let result = "";
+  while (num > 0) {
+    result = BASE62[num % 62] + result;
+    num = Math.floor(num / 62);
   }
-  return result;
+  return result.padStart(length, "0");
 }
+
+function datetimeToCode(datetimeStr: string): string {
+  // Input format: "D/M/YYYY h:mm:ss AM/PM"
+  const [datePart, timePart, ampm] = datetimeStr.split(" ");
+  const [day, month, year] = datePart.split("/").map(Number);
+
+  let [hour, minute, second] = timePart.split(":").map(Number);
+  if (ampm.toUpperCase() === "PM" && hour < 12) hour += 12;
+  if (ampm.toUpperCase() === "AM" && hour === 12) hour = 0;
+
+  // Build Date
+  const dt = new Date(year, month - 1, day, hour, minute, second);
+
+  const monthVal = dt.getMonth() + 1; // 1–12
+  const dayVal = dt.getDate();        // 1–31
+  const hourVal = dt.getHours();      // 0–23
+  const minuteVal = dt.getMinutes();  // 0–59
+
+  // Combine into 20-bit int
+  const code = (monthVal << 16) | (dayVal << 11) | (hourVal << 6) | minuteVal;
+
+  // Convert to base62, 4 characters
+  return toBase62(code, 4);
+}
+
+export function generateTicketId(orderId: string, datetimeStr: string): string {
+  const last4 = orderId.slice(-4);
+  const code = datetimeToCode(datetimeStr);
+  return code + last4;
+}
+
 
 export async function POST(request: NextRequest) {
   try {
@@ -28,7 +61,7 @@ export async function POST(request: NextRequest) {
     }
 
     const now = Timestamp.now();
-    const code = generateCode();
+    const code = generateTicketId('D_DAY', now.toDate().toLocaleString('en-US', { timeZone: 'Asia/Singapore' }));
     const ticketRef = await addDoc(collection(db, 'tickets'), {
       code,
       catA: Number(catA) || 0,

--- a/app/api/createCustomer/route.tsx
+++ b/app/api/createCustomer/route.tsx
@@ -3,7 +3,7 @@ import { cookies } from 'next/headers';
 import { verifyAdmin } from '@/lib/auth';
 import { ApiError, UnauthorizedError } from '@/lib/error';
 import { db } from '@/db/source';
-import { collection, doc, setDoc, Timestamp } from 'firebase/firestore';
+import { collection, addDoc, Timestamp } from 'firebase/firestore';
 
 function generateCode(length = 8) {
   const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
@@ -28,10 +28,8 @@ export async function POST(request: NextRequest) {
     }
 
     const now = Timestamp.now();
-    const ticketRef = doc(collection(db, 'tickets'));
-    const ticketId = ticketRef.id;
     const code = generateCode();
-    await setDoc(ticketRef, {
+    const ticketRef = await addDoc(collection(db, 'tickets'), {
       code,
       catA: Number(catA) || 0,
       catB: Number(catB) || 0,
@@ -40,9 +38,9 @@ export async function POST(request: NextRequest) {
       checkedIn: false,
       lastUpdated: now,
     });
+    const ticketId = ticketRef.id;
 
-    const customerRef = doc(collection(db, 'customers'));
-    await setDoc(customerRef, {
+    await addDoc(collection(db, 'customers'), {
       email,
       ticketIds: [ticketId],
       lastUpdated: now,

--- a/components/admin/customer-create.tsx
+++ b/components/admin/customer-create.tsx
@@ -1,0 +1,93 @@
+'use client';
+import React, { useState } from 'react';
+
+export const CustomerCreate: React.FC = () => {
+  const [email, setEmail] = useState('');
+  const [catA, setCatA] = useState(0);
+  const [catB, setCatB] = useState(0);
+  const [catC, setCatC] = useState(0);
+  const [status, setStatus] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setStatus(null);
+    try {
+      const res = await fetch('/api/createCustomer', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, catA, catB, catC }),
+      });
+      const data = await res.json();
+      if (res.ok) {
+        setStatus(`Created ticket code: ${data.ticket.code}`);
+        setEmail('');
+        setCatA(0); setCatB(0); setCatC(0);
+      } else {
+        setStatus(data.error || 'Failed to create customer');
+      }
+    } catch {
+      setStatus('Failed to create customer');
+    }
+  };
+
+  const inputStyle: React.CSSProperties = {
+    padding: '0.75rem',
+    borderRadius: 6,
+    border: '2px solid #006400',
+    backgroundColor: '#004b23',
+    color: '#e6f2e6'
+  };
+
+  return (
+    <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '1rem', maxWidth: 360 }}>
+      <input
+        type="email"
+        placeholder="Email"
+        value={email}
+        onChange={e => setEmail(e.target.value)}
+        style={inputStyle}
+      />
+      <input
+        type="number"
+        min="0"
+        placeholder="CatA Tickets"
+        value={catA}
+        onChange={e => setCatA(parseInt(e.target.value) || 0)}
+        style={inputStyle}
+      />
+      <input
+        type="number"
+        min="0"
+        placeholder="CatB Tickets"
+        value={catB}
+        onChange={e => setCatB(parseInt(e.target.value) || 0)}
+        style={inputStyle}
+      />
+      <input
+        type="number"
+        min="0"
+        placeholder="CatC Tickets"
+        value={catC}
+        onChange={e => setCatC(parseInt(e.target.value) || 0)}
+        style={inputStyle}
+      />
+      {status && <div>{status}</div>}
+      <button
+        type="submit"
+        style={{
+          padding: '0.75rem',
+          backgroundColor: '#006400',
+          color: '#fff',
+          border: 'none',
+          borderRadius: 6,
+          cursor: 'pointer',
+          fontWeight: 600,
+        }}
+      >
+        Create Customer
+      </button>
+    </form>
+  );
+};
+
+export default CustomerCreate;

--- a/components/admin/customer-create.tsx
+++ b/components/admin/customer-create.tsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 
 export const CustomerCreate: React.FC = () => {
   const [email, setEmail] = useState('');
+  const [prefix, setPrefix] = useState('');
   const [catA, setCatA] = useState(0);
   const [catB, setCatB] = useState(0);
   const [catC, setCatC] = useState(0);
@@ -15,7 +16,7 @@ export const CustomerCreate: React.FC = () => {
       const res = await fetch('/api/createCustomer', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email, catA, catB, catC }),
+        body: JSON.stringify({ email, prefix, catA, catB, catC }),
       });
       const data = await res.json();
       if (res.ok) {
@@ -48,6 +49,17 @@ export const CustomerCreate: React.FC = () => {
           placeholder="Email"
           value={email}
           onChange={e => setEmail(e.target.value)}
+          style={inputStyle}
+        />
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
+        <label htmlFor="prefix">Ticket Prefix</label>
+        <input
+          id="prefix"
+          type="text"
+          placeholder=""
+          value={prefix}
+          onChange={e => setPrefix(e.target.value)}
           style={inputStyle}
         />
       </div>

--- a/components/admin/customer-create.tsx
+++ b/components/admin/customer-create.tsx
@@ -40,37 +40,50 @@ export const CustomerCreate: React.FC = () => {
 
   return (
     <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '1rem', maxWidth: 360 }}>
-      <input
-        type="email"
-        placeholder="Email"
-        value={email}
-        onChange={e => setEmail(e.target.value)}
-        style={inputStyle}
-      />
-      <input
-        type="number"
-        min="0"
-        placeholder="CatA Tickets"
-        value={catA}
-        onChange={e => setCatA(parseInt(e.target.value) || 0)}
-        style={inputStyle}
-      />
-      <input
-        type="number"
-        min="0"
-        placeholder="CatB Tickets"
-        value={catB}
-        onChange={e => setCatB(parseInt(e.target.value) || 0)}
-        style={inputStyle}
-      />
-      <input
-        type="number"
-        min="0"
-        placeholder="CatC Tickets"
-        value={catC}
-        onChange={e => setCatC(parseInt(e.target.value) || 0)}
-        style={inputStyle}
-      />
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
+        <label htmlFor="email">Email</label>
+        <input
+          id="email"
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={e => setEmail(e.target.value)}
+          style={inputStyle}
+        />
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
+        <label htmlFor="catA">Cat&nbsp;A Tickets</label>
+        <input
+          id="catA"
+          type="number"
+          min="0"
+          value={catA}
+          onChange={e => setCatA(parseInt(e.target.value) || 0)}
+          style={inputStyle}
+        />
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
+        <label htmlFor="catB">Cat&nbsp;B Tickets</label>
+        <input
+          id="catB"
+          type="number"
+          min="0"
+          value={catB}
+          onChange={e => setCatB(parseInt(e.target.value) || 0)}
+          style={inputStyle}
+        />
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
+        <label htmlFor="catC">Cat&nbsp;C Tickets</label>
+        <input
+          id="catC"
+          type="number"
+          min="0"
+          value={catC}
+          onChange={e => setCatC(parseInt(e.target.value) || 0)}
+          style={inputStyle}
+        />
+      </div>
       {status && <div>{status}</div>}
       <button
         type="submit"


### PR DESCRIPTION
## Summary
- Add `Create Customer` tab on admin dashboard for ticket creation
- Provide form to create customer and ticket counts
- Implement API route to save customer and ticket to Firestore

------
https://chatgpt.com/codex/tasks/task_e_68bc21b40b5883249e473def1398b5e1